### PR TITLE
Replace kint64max with -1 for limit_in_bytes.

### DIFF
--- a/lmctfy/resources/memory_resource_handler.cc
+++ b/lmctfy/resources/memory_resource_handler.cc
@@ -112,12 +112,12 @@ Status MemoryResourceHandler::Update(const ContainerSpec &spec,
   // - If no limit specified, default to MAX_INT64.
   // - If no reservation specified, default to 0.
 
-  // Set the limit. The default is MAX_INT64 if it was not specified during a
-  // replace.
+  // Set the limit. The default is -1 if it was not specified during a replace.
+  // The kernel interprets it as the maximum permissible value.
   if (memory_spec.has_limit()) {
     RETURN_IF_ERROR(memory_controller_->SetLimit(Bytes(memory_spec.limit())));
   } else if (policy == Container::UPDATE_REPLACE) {
-    RETURN_IF_ERROR(memory_controller_->SetLimit(Bytes(kint64max)));
+    RETURN_IF_ERROR(memory_controller_->SetLimit(Bytes(-1)));
   }
 
   // Set the reservation if it was specified. The default is 0 if it was not

--- a/lmctfy/resources/memory_resource_handler_test.cc
+++ b/lmctfy/resources/memory_resource_handler_test.cc
@@ -399,7 +399,7 @@ TEST_F(MemoryResourceHandlerTest, UpdateDiffWithReservationFails) {
 TEST_F(MemoryResourceHandlerTest, UpdateReplaceEmpty) {
   ContainerSpec spec;
 
-  EXPECT_CALL(*mock_memory_controller_, SetLimit(Bytes(kint64max)))
+  EXPECT_CALL(*mock_memory_controller_, SetLimit(Bytes(-1)))
       .WillOnce(Return(Status::OK));
   EXPECT_CALL(*mock_memory_controller_, SetSoftLimit(Bytes(0)))
       .WillOnce(Return(Status::OK));


### PR DESCRIPTION
The kernel rejects kint64max values with EINVAL on 3.8.0-19 when
writing to "memory.limit_in_bytes".  It accepts values up to
(kint64max & ~(PAGE_SIZE-1)).  My suspicion is that when lmctfy passes
kint64max, somewhere its being parsed as an int64 and also being
aligned to the next page boundary.  This is not surprising given
that I can reproduce this without lmctfy also --

echo 9223372036854775807 >/dev/cgroup/memory/test/memory.limit_in_bytes
bash: echo: write error: Invalid argument

It seems that -1 is the proper way of telling the kernel to set
max limit (from looking at mem_cgroup_write() in memcontrol.cc and
Documentation/cgroups/memory.txt).

echo -1 >/dev/cgroup/memory/test/memory.limit_in_bytes
cat /dev/cgroup/memory/test/memory.limit_in_bytes
9223372036854775807
