### PR TITLE
cgroup mounts should happen before ContainerApiImpl initialization.

### DIFF
--- a/lmctfy/lmctfy_impl.cc
+++ b/lmctfy/lmctfy_impl.cc
@@ -340,6 +340,10 @@ Status ContainerApi::InitMachine(const InitSpec &spec) {
 Status ContainerApiImpl::InitMachineImpl(const KernelApi *kernel,
                                      unique_ptr<CgroupFactory> cgroup_factory,
                                      const InitSpec &spec) {
+  for (auto &mount : spec.cgroup_mount()) {
+    RETURN_IF_ERROR(cgroup_factory->Mount(mount));
+  }
+
   unique_ptr<ContainerApiImpl> lmctfy(
       RETURN_IF_ERROR(
           ContainerApiImpl::NewContainerApiImpl(move(cgroup_factory), kernel)));
@@ -570,10 +574,6 @@ StatusOr<string> ContainerApiImpl::Detect(pid_t tid) const {
 }
 
 Status ContainerApiImpl::InitMachine(const InitSpec &spec) const {
-  for (auto &mount : spec.cgroup_mount()) {
-    RETURN_IF_ERROR(cgroup_factory_->Mount(mount));
-  }
-
   // Initialize the resource handlers.
   for (auto type_handler_pair : resource_factories_) {
     RETURN_IF_ERROR(type_handler_pair.second->InitMachine(spec));

--- a/lmctfy/lmctfy_impl_test.cc
+++ b/lmctfy/lmctfy_impl_test.cc
@@ -166,17 +166,6 @@ class ContainerApiImplTest : public ::testing::Test {
                 mock_freezer_controller_factory_)));
   }
 
-  void ExpectCgroupFactoryMountCall(const CgroupMount &cgroup) {
-    EXPECT_CALL(*mock_cgroup_factory_, Mount(EqualsInitializedProto(cgroup)))
-        .WillOnce(Return(Status::OK));
-  }
-
-  void ExpectCgroupFactoryMountFailure(const CgroupMount &cgroup,
-                                       const Status &error) {
-    EXPECT_CALL(*mock_cgroup_factory_, Mount(EqualsInitializedProto(cgroup)))
-        .WillOnce(Return(error));
-  }
-
   void ExpectResourceFactoriesInitMachineCall(const InitSpec &init_spec) {
     for (const auto rfactory : resource_factories_) {
       EXPECT_CALL(
@@ -308,42 +297,23 @@ TEST_F(ContainerApiImplTest, InitMachineSuccess) {
 
   InitSpec spec;
   spec.add_cgroup_mount()->CopyFrom(mount1);
-  ExpectCgroupFactoryMountCall(mount1);
 
   spec.add_cgroup_mount()->CopyFrom(mount2);
-  ExpectCgroupFactoryMountCall(mount2);
 
   spec.add_cgroup_mount()->CopyFrom(mount3);
-  ExpectCgroupFactoryMountCall(mount3);
 
   spec.add_cgroup_mount()->CopyFrom(mount4);
-  ExpectCgroupFactoryMountCall(mount4);
 
   spec.add_cgroup_mount()->CopyFrom(mount5);
-  ExpectCgroupFactoryMountCall(mount5);
 
   spec.add_cgroup_mount()->CopyFrom(mount6);
-  ExpectCgroupFactoryMountCall(mount6);
 
   spec.add_cgroup_mount()->CopyFrom(mount7);
-  ExpectCgroupFactoryMountCall(mount7);
 
   ExpectResourceFactoriesInitMachineCall(spec);
   ExpectNamespaceHandlerFactoryInitMachine(spec);
 
   EXPECT_OK(lmctfy_->InitMachine(spec));
-}
-
-TEST_F(ContainerApiImplTest, InitMachineMountFails) {
-  CgroupMount mount1;
-  mount1.set_mount_path("/dev/cgroup/memory");
-  mount1.add_hierarchy(CGROUP_MEMORY);
-
-  InitSpec spec;
-  spec.add_cgroup_mount()->CopyFrom(mount1);
-  ExpectCgroupFactoryMountFailure(mount1, Status(INTERNAL, "blah"));
-
-  EXPECT_NOT_OK(lmctfy_->InitMachine(spec));
 }
 
 TEST_F(ContainerApiImplTest, InitMachineResourceInitFails) {
@@ -353,7 +323,6 @@ TEST_F(ContainerApiImplTest, InitMachineResourceInitFails) {
 
   InitSpec spec;
   spec.add_cgroup_mount()->CopyFrom(mount1);
-  ExpectCgroupFactoryMountCall(mount1);
 
   EXPECT_CALL(
       *reinterpret_cast<MockResourceHandlerFactory *>(resource_factories_[0]),
@@ -370,7 +339,7 @@ TEST_F(ContainerApiImplTest, InitMachineNamespaceFactoryInitMachineFails) {
 
   InitSpec spec;
   spec.add_cgroup_mount()->CopyFrom(mount1);
-  ExpectCgroupFactoryMountCall(mount1);
+
   ExpectResourceFactoriesInitMachineCall(spec);
   ExpectNamespaceHandlerFactoryInitMachineFails(spec);
 


### PR DESCRIPTION
ContainerApiImpl factory method expects cgroups to be mounted therefore
when doing machine initalization we have to mount them first.

This fixes issue #33.
